### PR TITLE
ci(android): sign playstore builds with their own upload keystore

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     },
     "scripts": {
         "createBase64Key": "openssl base64 < $KEYSTORE_PATH | tr -d '\n' | tee base64.txt",
+        "createBase64PlaystoreKey": "openssl base64 < $PLAYSTORE_KEYSTORE_PATH | tr -d '\n' | tee base64.playstore.txt",
         "postinstall": "npm run setup",
         "prepare": "ts-patch install -s",
         "prepare.ios.sentry": "NS_SENTRY=1 PLAY_STORE_BUILD=1 ns prepare ios --release --env.adhoc_sentry",
@@ -20,8 +21,8 @@
         "run.android.production.sentry": "NS_SENTRY=1 cross-var ns run android --release --key-store-path $KEYSTORE_PATH --key-store-password $KEYSTORE_PASSWORD --key-store-alias $KEYSTORE_ALIAS --key-store-alias-password $KEYSTORE_ALIAS_PASSWORD --env.adhoc_sentry --env.sentryUpload=0 --env.sourceMap=0  --env.devlog --gradleArgs=-PsentryEnabled",
         "run.android.timeline": "NS_LOGGING=1 NS_TIMELINE=1 cross-var ns run android --release --key-store-path $KEYSTORE_PATH --key-store-password $KEYSTORE_PASSWORD --key-store-alias $KEYSTORE_ALIAS --key-store-alias-password $KEYSTORE_ALIAS_PASSWORD --env.timeline",
         "build.android.production": "cross-var ns build android --release --clean --key-store-path $KEYSTORE_PATH --key-store-password $KEYSTORE_PASSWORD --key-store-alias $KEYSTORE_ALIAS --key-store-alias-password $KEYSTORE_ALIAS_PASSWORD --env.adhoc --env.sentry=0 --env.sourceMap=0  --env.report",
-        "build.android.production.playstore": "PLAY_STORE_BUILD=1 npm run build.android.production -- --aab",
-        "build.android.production.playstore.sentry": "NS_SENTRY=1 PLAY_STORE_BUILD=1 cross-var ns build android --release --clean --key-store-path $KEYSTORE_PATH --key-store-password $KEYSTORE_PASSWORD --key-store-alias $KEYSTORE_ALIAS --key-store-alias-password $KEYSTORE_ALIAS_PASSWORD --env.adhoc_sentry --env.report --aab --gradleArgs=-PsentryEnabled",
+        "build.android.production.playstore": "PLAY_STORE_BUILD=1 cross-var ns build android --release --clean --key-store-path $PLAYSTORE_KEYSTORE_PATH --key-store-password $KEYSTORE_PASSWORD --key-store-alias $KEYSTORE_ALIAS --key-store-alias-password $KEYSTORE_ALIAS_PASSWORD --env.adhoc --env.sentry=0 --env.sourceMap=0  --env.report --aab",
+        "build.android.production.playstore.sentry": "NS_SENTRY=1 PLAY_STORE_BUILD=1 cross-var ns build android --release --clean --key-store-path $PLAYSTORE_KEYSTORE_PATH --key-store-password $KEYSTORE_PASSWORD --key-store-alias $KEYSTORE_ALIAS --key-store-alias-password $KEYSTORE_ALIAS_PASSWORD --env.adhoc_sentry --env.report --aab --gradleArgs=-PsentryEnabled",
         "build.android.production.fdroid": "cross-var ns build android --release --clean --key-store-path $KEYSTORE_PATH --key-store-password $KEYSTORE_PASSWORD --key-store-alias $KEYSTORE_ALIAS --key-store-alias-password $KEYSTORE_ALIAS_PASSWORD --env.adhoc --env.playStoreBuild=0 --env.report --gradleArgs=-PsplitEnabled  --gradleArgs=-PabiFilters=arm64-v8a,armeabi-v7a",
         "build.android.production.fdroid.sentry": "NS_SENTRY=1 npm run build.android.production.fdroid -- --env.adhoc_sentry --gradleArgs=-PsentryEnabled",
         "build.android.debug.sentry": "NS_SENTRY=1 ns build android --env.adhoc_sentry --env.production=0 --gradleArgs=-PsplitEnabled  --gradleArgs=-PabiFilters=arm64-v8a,armeabi-v7a --gradleArgs=-PsentryEnabled",

--- a/scripts/ci.prepare.sh
+++ b/scripts/ci.prepare.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Called by the shared app-tools release workflows before the build.
+# The workflow only knows how to decode a single keystore (KEYSTORE_BASE64 -> KEYSTORE_PATH),
+# which is the github/fdroid one. The playstore upload key is a different certificate,
+# so decode it here from PLAYSTORE_KEYSTORE_BASE64 -> PLAYSTORE_KEYSTORE_PATH.
+set -e
+
+platform=''
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --platform)
+            platform="$2"
+            shift 2
+            ;;
+        --flavor | --version)
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+[ "$platform" = 'android' ] || exit 0
+
+if [ -z "$PLAYSTORE_KEYSTORE_BASE64" ]; then
+    echo "PLAYSTORE_KEYSTORE_BASE64 not set, skipping playstore keystore decoding"
+    exit 0
+fi
+
+if [ -z "$PLAYSTORE_KEYSTORE_PATH" ]; then
+    echo "PLAYSTORE_KEYSTORE_PATH not set while PLAYSTORE_KEYSTORE_BASE64 is" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$PLAYSTORE_KEYSTORE_PATH")"
+printf '%s' "$PLAYSTORE_KEYSTORE_BASE64" | base64 -d > "$PLAYSTORE_KEYSTORE_PATH"
+echo "decoded playstore keystore to $PLAYSTORE_KEYSTORE_PATH"


### PR DESCRIPTION
## Summary

- Playstore aab builds (`build.android.production.playstore` / `.sentry`) now sign with `$PLAYSTORE_KEYSTORE_PATH` (`certs/upload-keystore.jks`) instead of `$KEYSTORE_PATH`. The github/fdroid apk, `run.android.*` and the benchmark build keep `$KEYSTORE_PATH` (`certs/upload.keystore`). The two are different certificates, so one variable could not cover both.
- `build.android.production.playstore` no longer delegates to `build.android.production` — it is spelled out so it can carry its own key-store path. Flags are otherwise identical.
- New `scripts/ci.prepare.sh` decodes the playstore keystore in CI. The shared app-tools workflow already invokes this file when it exists, before its own single-keystore `Decode Keystore` step, so no submodule change is needed. It no-ops on iOS and when the secret is absent.
- New `createBase64PlaystoreKey` script to produce the base64 blob for the secret.

Alias and passwords are unchanged and shared between both keystores.

## Deployment steps

Both are needed before the next Android release run:

1. Add `PLAYSTORE_KEYSTORE_PATH=certs/upload-keystore.jks` to `.env.ci` (untracked here — not part of this diff).
2. Add a `PLAYSTORE_KEYSTORE_BASE64` repository secret, from `yarn createBase64PlaystoreKey`. Existing `KEYSTORE_BASE64` / `KEYSTORE_PATH` secrets stay as they are — the shared workflow still requires `KEYSTORE_PATH` to be non-empty.

## Testing

- `scripts/ci.prepare.sh`: `sh -n` clean; verified the iOS and missing-secret paths no-op with exit 0, and that a full base64 round-trip reproduces the keystore (SHA1 `39:17:AD:...` matches `certs/upload-keystore.jks`).
- Not verified: an actual aab build (needs the native toolchain) and a real CI run. After the first build, confirm signing with `keytool -printcert -jarfile <aab>` — expect SHA1 `39:17:AD:...` for the aab and `3E:02:C5:...` for the fdroid apk.